### PR TITLE
ci: fix Conda build toolchain compatibility

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   registry-check:
-    runs-on: windows-latest
+    # ROS Humble 与 Windows 原生扩展依赖固定的 VS 2022 运行时；与构建矩阵
+    # 使用同一映像，避免 latest 漂移后在导入校验阶段触发原生崩溃。
+    runs-on: windows-2022
 
     env:
       # Fix Unicode encoding issue on Windows runner (cp1252 -> utf-8)

--- a/.github/workflows/multi-platform-build.yml
+++ b/.github/workflows/multi-platform-build.yml
@@ -123,6 +123,9 @@ jobs:
           echo "CONDA_NO_PLUGINS=true" >> "$GITHUB_ENV"
           echo "PYTHONUTF8=1" >> "$GITHUB_ENV"
           echo "PYTHONIOENCODING=utf-8" >> "$GITHUB_ENV"
+          # anaconda-client 1.13+ 将顶层 anaconda CLI 改为插件入口；
+          # 用其兼容的 standalone 入口检查客户端版本。
+          echo "ANACONDA_CLIENT_FORCE_STANDALONE=1" >> "$GITHUB_ENV"
 
       - name: Show environment info
         if: steps.should_build.outputs.should_build == 'true'
@@ -130,7 +133,7 @@ jobs:
           conda info
           conda list -n build-env | grep -E "(rattler-build|anaconda-client)"
           conda run -n build-env rattler-build --version
-          conda run -n build-env anaconda --version
+          conda run -n build-env python -m binstar_client.scripts.cli --version
           echo "Platform: ${{ matrix.platform }}"
           echo "OS: ${{ matrix.os }}"
 

--- a/.github/workflows/multi-platform-build.yml
+++ b/.github/workflows/multi-platform-build.yml
@@ -69,7 +69,9 @@ jobs:
           - os: macos-latest # ARM64
             platform: osx-arm64
             env_file: unilabos-osx-arm64.yaml
-          - os: windows-latest
+          # bld_ament_cmake.bat uses the VS 2022 generator; windows-latest
+          # moved to an image with VS 2026 and no longer provides that generator.
+          - os: windows-2022
             platform: win-64
             env_file: unilabos-win64.yaml
 

--- a/.github/workflows/unilabos-conda-build.yml
+++ b/.github/workflows/unilabos-conda-build.yml
@@ -63,7 +63,9 @@ jobs:
             platform: osx-64
           - os: macos-latest # ARM64
             platform: osx-arm64
-          - os: windows-latest
+          # bld_ament_cmake.bat uses the VS 2022 generator; keep the runner
+          # aligned with the compiler package and its installed generator.
+          - os: windows-2022
             platform: win-64
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unilabos-conda-build.yml
+++ b/.github/workflows/unilabos-conda-build.yml
@@ -116,6 +116,9 @@ jobs:
           echo "CONDA_NO_PLUGINS=true" >> "$GITHUB_ENV"
           echo "PYTHONUTF8=1" >> "$GITHUB_ENV"
           echo "PYTHONIOENCODING=utf-8" >> "$GITHUB_ENV"
+          # anaconda-client 1.13+ 将顶层 anaconda CLI 改为插件入口；
+          # 用其兼容的 standalone 入口检查客户端版本。
+          echo "ANACONDA_CLIENT_FORCE_STANDALONE=1" >> "$GITHUB_ENV"
 
       - name: Show environment info
         if: steps.should_build.outputs.should_build == 'true'
@@ -123,7 +126,7 @@ jobs:
           conda info
           conda list -n build-env | grep -E "(rattler-build|anaconda-client)"
           conda run -n build-env rattler-build --version
-          conda run -n build-env anaconda --version
+          conda run -n build-env python -m binstar_client.scripts.cli --version
           echo "Platform: ${{ matrix.platform }}"
           echo "OS: ${{ matrix.os }}"
           echo "Build full package: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_full == 'true' }}"

--- a/recipes/msgs/build_ament_cmake.sh
+++ b/recipes/msgs/build_ament_cmake.sh
@@ -41,9 +41,10 @@ if [[ $target_platform =~ linux.* ]]; then
 fi;
 
 # Apple libc++ 21 hides the C++26-removed conversion helpers by default;
-# Humble's generated rosidl_runtime_cpp headers still use wstring_convert.
+# Humble's generated rosidl_runtime_cpp headers still use wstring_convert and
+# include <codecvt> without the <locale> header that declares the type.
 if [[ $target_platform =~ osx.* ]]; then
-    export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT"
+    export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT -include locale"
 fi;
 
 # Needed for qt-gui-cpp ..

--- a/recipes/msgs/build_ament_cmake.sh
+++ b/recipes/msgs/build_ament_cmake.sh
@@ -40,6 +40,12 @@ if [[ $target_platform =~ linux.* ]]; then
     export CXXFLAGS="${CXXFLAGS} -D__STDC_FORMAT_MACROS=1"
 fi;
 
+# Apple libc++ 21 hides the C++26-removed conversion helpers by default;
+# Humble's generated rosidl_runtime_cpp headers still use wstring_convert.
+if [[ $target_platform =~ osx.* ]]; then
+    export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT"
+fi;
+
 # Needed for qt-gui-cpp ..
 if [[ $target_platform =~ linux.* ]]; then
   ln -s $GCC ${BUILD_PREFIX}/bin/gcc

--- a/recipes/msgs/recipe.yaml
+++ b/recipes/msgs/recipe.yaml
@@ -64,6 +64,8 @@ requirements:
   - robostack-staging::ros-humble-std-msgs
   - robostack-staging::ros-humble-geometry-msgs
   - robostack-staging::ros2-distro-mutex=0.7
+  # Humble rosidl_adapter 使用 EmPy 3 API；EmPy 4 移除了 BUFFERED_OPT。
+  - empy ==3.3.4
   run:
   - robostack-staging::ros-humble-action-msgs
   - robostack-staging::ros-humble-ros-workspace

--- a/unilabos/devices/raman_uv/home_made_raman.py
+++ b/unilabos/devices/raman_uv/home_made_raman.py
@@ -2,10 +2,6 @@ import json
 import serial
 import struct
 import crcmod
-import tkinter as tk
-from tkinter import messagebox
-import matplotlib.pyplot as plt
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import time
 
 class RamanObj:
@@ -127,6 +123,8 @@ class RamanObj:
             data = receive_data(serial_port, 4136)
 
             if not data or len(data) != 4136:
+                from tkinter import messagebox
+
                 messagebox.showerror("\u9519\u8bef", "\u63a5\u6536\u6570\u636e\u5931\u8d25\u6216\u6570\u636e\u957f\u5ea6\u4e0d\u6b63\u786e")
                 return
 
@@ -140,6 +138,8 @@ class RamanObj:
             print(f"\u8fd4\u56de\u503c: {values}")
             return values
         except Exception as e:
+            from tkinter import messagebox
+
             messagebox.showerror("\u9519\u8bef", f"\u4e32\u53e3\u521d\u59cb\u5316\u5931\u8d25: {e}")
             return None
 
@@ -182,6 +182,8 @@ class RamanObj:
             raise f"error: {e}"
 
 if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+
     raman = RamanObj(port_laser='COM20', port_ccd='COM2')
     ccd_data = raman.raman_without_background_average('test44',0.5,3000,1)
 

--- a/unilabos/registry/registry.py
+++ b/unilabos/registry/registry.py
@@ -1387,6 +1387,10 @@ class Registry:
         total_items = len(self.device_type_registry) + len(self.resource_type_registry)
 
         lock = threading.Lock()
+        # importlib、ImportManager 以及部分 ROS/Windows 原生扩展并不保证可并发初始化。
+        # 注册表校验只需验证导入和生成 schema，串行化这一段可避免进程级访问冲突；
+        # 外层任务结构仍保留，便于统一收集错误。
+        import_lock = threading.Lock()
 
         def _verify_device(device_id: str, entry: dict):
             nonlocal import_success_count, resolved_count
@@ -1397,16 +1401,17 @@ class Registry:
                 return None
 
             try:
-                cls = import_class(module_str)
-                with lock:
-                    import_success_count += 1
-                    resolved_count += 1
+                with import_lock:
+                    cls = import_class(module_str)
+                    with lock:
+                        import_success_count += 1
+                        resolved_count += 1
 
-                # 尝试用动态信息增强注册表
-                try:
-                    self.resolve_types_for_device(device_id, cls)
-                except Exception as e:
-                    logger.debug(f"[UniLab Registry/Verify] 设备 {device_id} 类型解析失败: {e}")
+                    # 尝试用动态信息增强注册表
+                    try:
+                        self.resolve_types_for_device(device_id, cls)
+                    except Exception as e:
+                        logger.debug(f"[UniLab Registry/Verify] 设备 {device_id} 类型解析失败: {e}")
 
                 return None
             except Exception as e:
@@ -1425,9 +1430,10 @@ class Registry:
                 return None
 
             try:
-                import_class(module_str)
-                with lock:
-                    import_success_count += 1
+                with import_lock:
+                    import_class(module_str)
+                    with lock:
+                        import_success_count += 1
                 return None
             except Exception as e:
                 logger.warning(

--- a/unilabos/registry/registry.py
+++ b/unilabos/registry/registry.py
@@ -1379,7 +1379,9 @@ class Registry:
 
     def verify_and_resolve_registry(self):
         """
-        对 AST 扫描得到的注册表执行实际 import 验证（使用共享线程池并行）。
+        对 AST 扫描得到的注册表执行实际 import 验证。
+
+        使用共享线程池收集任务，但将原生模块导入和动态 schema 增强串行化。
         """
         errors = []
         import_success_count = 0
@@ -1390,7 +1392,8 @@ class Registry:
         # importlib、ImportManager 以及部分 ROS/Windows 原生扩展并不保证可并发初始化。
         # 注册表校验只需验证导入和生成 schema，串行化这一段可避免进程级访问冲突；
         # 外层任务结构仍保留，便于统一收集错误。
-        import_lock = threading.Lock()
+        # 使用可重入锁，避免 schema 解析间接触发 import_class 时自锁。
+        import_lock = threading.RLock()
 
         def _verify_device(device_id: str, entry: dict):
             nonlocal import_success_count, resolved_count


### PR DESCRIPTION
## Root causes

Run #33820711958 installed its tools successfully on all four runners, then failed in `Show environment info` because the plugin-based `anaconda` CLI no longer accepts the top-level `--version` option.

After fixing that check in a targeted Linux run, the next build failure was the known ROS Humble/EmPy incompatibility: the solver selected `empy 4.2.1`, while Humble `rosidl_adapter` uses the EmPy 3 API (`em.BUFFERED_OPT`).

## Fix

- use `python -m binstar_client.scripts.cli --version` with `ANACONDA_CLIENT_FORCE_STANDALONE=1`
- apply the CLI correction to both Conda build workflows
- pin `empy ==3.3.4` in the Humble message recipe

## Validation

- `git diff --check`
- parsed both workflow files and the recipe with PyYAML
- isolated `anaconda-client==1.14.1` CLI check exited 0
- targeted Linux run #33847326687 passed `Show environment info`; its later recipe failure is the reason for the additional EmPy pin

This PR targets `main` because `workflow_run` uses the default-branch workflow definition even when it checks out a triggering `dev` SHA.